### PR TITLE
Removing Cname domain as it was already in use

### DIFF
--- a/CNAME
+++ b/CNAME
@@ -1,1 +1,0 @@
-hyde.getpoole.com


### PR DESCRIPTION
Removed the hyde domain as it was generating a warning about it already being used.